### PR TITLE
Examples with .NET Core Logging

### DIFF
--- a/Examples/CircuitBreaking/Subscriber/FooHandler.cs
+++ b/Examples/CircuitBreaking/Subscriber/FooHandler.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Contract;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 
 namespace Subscriber
 {
     public class FooHandler : IHandleEvent<Foo>
     {
-        private readonly ILog _log;
+        private readonly ILogger _logger;
 
-        public FooHandler(ILog log)
+        public FooHandler(ILogger logger)
         {
-            _log = log;
+            _logger = logger;
         }
 
         public Task HandleAsync(Foo @event)
         {
-            _log.Info($"Handling: {@event}");
+            _logger.LogInformation($"Handling: {@event}");
             if (DateTime.UtcNow.Minute % 5 == 0)
             {
                 throw new ExternalProviderOfflineException();

--- a/Examples/CircuitBreaking/Subscriber/Program.cs
+++ b/Examples/CircuitBreaking/Subscriber/Program.cs
@@ -2,12 +2,8 @@
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using log4net;
-using log4net.Appender;
-using log4net.Core;
-using log4net.Layout;
-using log4net.Repository.Hierarchy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 using Pat.Subscriber.CicuitBreaker;
 using Pat.Subscriber.NetCoreDependencyResolution;
@@ -24,14 +20,14 @@ namespace Subscriber
             var tokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, args) =>
             {
-                var log = serviceProvider.GetService<ILog>();
-                log.Info("Subscriber Shutdown Requested");
+                var log = serviceProvider.GetService<ILogger>();
+                log.LogInformation("Subscriber Shutdown Requested");
                 args.Cancel = true;
                 tokenSource.Cancel();
             };
 
             var subscriber = serviceProvider.GetService<Pat.Subscriber.Subscriber>();
-            await subscriber.Initialise(new[] {Assembly.GetExecutingAssembly()});
+            await subscriber.Initialise(new[] { Assembly.GetExecutingAssembly() });
             await subscriber.ListenForMessages(tokenSource);
         }
 
@@ -42,13 +38,11 @@ namespace Subscriber
 
             var subscriberConfiguration = new SubscriberConfiguration
             {
-                ConnectionStrings = new[] {connection},
+                ConnectionStrings = new[] { connection },
                 TopicName = topicName,
                 SubscriberName = "PatExampleSubscriber",
                 UseDevelopmentTopic = false
             };
-
-            InitLogger();
 
             var patLiteOptions = new PatLiteOptionsBuilder(subscriberConfiguration)
                 .UseDefaultPipelinesWithCircuitBreaker(s => s.GetService<CircuitBreakerBatchProcessingBehaviour.CircuitBreakerOptions>())
@@ -73,37 +67,16 @@ namespace Subscriber
                         var monitoring = provider.GetService<CircuitBreakerMonitoring>();
                         monitoring.CircuitTest();
                     }
-                })                    
+                })
                 .AddPatLite(patLiteOptions)
-                .AddTransient(s => LogManager.GetLogger(s.GetType()))
+                .AddDefaultPatLogger()
+                .AddLogging(b => b.AddConsole())
                 .AddTransient<IStatisticsReporter, StatisticsReporter>()
                 .AddSingleton(new StatisticsReporterConfiguration())
                 .AddHandlersFromAssemblyContainingType<FooHandler>()
                 .BuildServiceProvider();
 
             return serviceProvider;
-        }
-
-        private static void InitLogger()
-        {
-            var hierarchy = (Hierarchy)LogManager.GetRepository(Assembly.GetExecutingAssembly());
-            var tracer = new TraceAppender();
-            var patternLayout = new PatternLayout();
-
-            patternLayout.ConversionPattern = "%d [%t] %-5p %m%n";
-            patternLayout.ActivateOptions();
-
-            tracer.Layout = patternLayout;
-            tracer.ActivateOptions();
-            hierarchy.Root.AddAppender(tracer);
-
-            var appender = new ConsoleAppender();
-            appender.Layout = patternLayout;
-            appender.ActivateOptions();
-            hierarchy.Root.AddAppender(appender);
-
-            hierarchy.Root.Level = Level.Info;
-            hierarchy.Configured = true;
         }
     }
 }

--- a/Examples/CircuitBreaking/Subscriber/Subscriber.csproj
+++ b/Examples/CircuitBreaking/Subscriber/Subscriber.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pat.Subscriber" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.RateLimiterPolicy" Version="1.1.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Pat.Subscriber" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.RateLimiterPolicy" Version="2.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/HelloWorldNetCore/Subscriber/FooHandler.cs
+++ b/Examples/HelloWorldNetCore/Subscriber/FooHandler.cs
@@ -1,22 +1,22 @@
 ﻿using System.Threading.Tasks;
 using Contract;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 
 namespace Subscriber
 {
     public class FooHandler : IHandleEvent<Foo>
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
 
-        public FooHandler(ILog log)
+        public FooHandler(ILogger log)
         {
             _log = log;
         }
 
         public Task HandleAsync(Foo @event)
         {
-            _log.Info($"Handling: {@event}");
+            _log.LogInformation($"Handling: {@event}");
             return Task.CompletedTask;
         }
     }

--- a/Examples/HelloWorldNetCore/Subscriber/Subscriber.csproj
+++ b/Examples/HelloWorldNetCore/Subscriber/Subscriber.csproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pat.Subscriber" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="1.1.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Pat.Subscriber" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="2.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/HelloWorldNetFramework/Subscriber/FooHandler.cs
+++ b/Examples/HelloWorldNetFramework/Subscriber/FooHandler.cs
@@ -1,22 +1,22 @@
 ﻿using System.Threading.Tasks;
 using Contract;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 
 namespace Subscriber
 {
     public class FooHandler : IHandleEvent<Foo>
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
 
-        public FooHandler(ILog log)
+        public FooHandler(ILogger log)
         {
             _log = log;
         }
 
         public Task HandleAsync(Foo @event)
         {
-            _log.Info($"Handling: {@event}");
+            _log.LogInformation($"Handling: {@event}");
             return Task.CompletedTask;
         }
     }

--- a/Examples/HelloWorldNetFramework/Subscriber/Subscriber.csproj
+++ b/Examples/HelloWorldNetFramework/Subscriber/Subscriber.csproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pat.Subscriber" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.StructureMap4DependencyResolution" Version="1.1.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Pat.Subscriber" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.StructureMap4DependencyResolution" Version="2.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/NonTransientMessageFailureHandling/Subscriber/FooHandler.cs
+++ b/Examples/NonTransientMessageFailureHandling/Subscriber/FooHandler.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Contract;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 
 namespace Subscriber
 {
     public class FooHandler : IHandleEvent<Foo>
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
 
-        public FooHandler(ILog log)
+        public FooHandler(ILogger log)
         {
             _log = log;
         }
 
         public Task HandleAsync(Foo @event)
         {
-            _log.Info($"Handling: {@event}");
+            _log.LogInformation($"Handling: {@event}");
             if (DateTime.UtcNow.Minute % 3 == 0)
             {
                 throw new SampleTransientException();

--- a/Examples/NonTransientMessageFailureHandling/Subscriber/NonTransientMessageFailureProcessingBehaviour.cs
+++ b/Examples/NonTransientMessageFailureHandling/Subscriber/NonTransientMessageFailureProcessingBehaviour.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 using Pat.Subscriber.MessageProcessing;
 
@@ -8,10 +8,10 @@ namespace Subscriber
 {
     internal class NonTransientMessageFailureProcessingBehaviour : DefaultMessageProcessingBehaviour
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
         private readonly SubscriberConfiguration _config;
 
-        public NonTransientMessageFailureProcessingBehaviour(ILog log, SubscriberConfiguration config) : base(log, config)
+        public NonTransientMessageFailureProcessingBehaviour(ILogger log, SubscriberConfiguration config) : base(log, config)
         {
             _log = log;
             _config = config;
@@ -25,7 +25,7 @@ namespace Subscriber
                 var messageType = GetMessageType(message);
                 var correlationId = GetCorrelationId(message);
                 await messageContext.MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
-                _log.Warn($"{ex.GetType()}: message deadlettered. `{messageType}` correlation id `{correlationId}` on subscriber `{_config.SubscriberName}`.", ex);
+                _log.LogWarning($"{ex.GetType()}: message deadlettered. `{messageType}` correlation id `{correlationId}` on subscriber `{_config.SubscriberName}`.", ex);
             }
             else
             {

--- a/Examples/NonTransientMessageFailureHandling/Subscriber/Program.cs
+++ b/Examples/NonTransientMessageFailureHandling/Subscriber/Program.cs
@@ -2,12 +2,8 @@
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using log4net;
-using log4net.Appender;
-using log4net.Core;
-using log4net.Layout;
-using log4net.Repository.Hierarchy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 using Pat.Subscriber.MessageProcessing;
 using Pat.Subscriber.NetCoreDependencyResolution;
@@ -24,14 +20,14 @@ namespace Subscriber
             var tokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, args) =>
             {
-                var log = serviceProvider.GetService<ILog>();
-                log.Info("Subscriber Shutdown Requested");
+                var log = serviceProvider.GetService<ILogger>();
+                log.LogInformation("Subscriber Shutdown Requested");
                 args.Cancel = true;
                 tokenSource.Cancel();
             };
 
             var subscriber = serviceProvider.GetService<Pat.Subscriber.Subscriber>();
-            await subscriber.Initialise(new[] {Assembly.GetExecutingAssembly()});
+            await subscriber.Initialise(new[] { Assembly.GetExecutingAssembly() });
             await subscriber.ListenForMessages(tokenSource);
         }
 
@@ -42,13 +38,11 @@ namespace Subscriber
 
             var subscriberConfiguration = new SubscriberConfiguration
             {
-                ConnectionStrings = new[] {connection},
+                ConnectionStrings = new[] { connection },
                 TopicName = topicName,
                 SubscriberName = "PatExampleSubscriber",
                 UseDevelopmentTopic = false
             };
-
-            InitLogger();
 
             var patLiteOptions = new PatLiteOptionsBuilder(subscriberConfiguration)
                 .DefineMessagePipeline
@@ -59,35 +53,14 @@ namespace Subscriber
 
             var serviceProvider = new ServiceCollection()
                 .AddPatLite(patLiteOptions)
-                .AddTransient(s => LogManager.GetLogger(s.GetType()))
+                .AddDefaultPatLogger()
+                .AddLogging(b => b.AddConsole())
                 .AddTransient<IStatisticsReporter, StatisticsReporter>()
                 .AddSingleton(new StatisticsReporterConfiguration())
                 .AddHandlersFromAssemblyContainingType<FooHandler>()
                 .BuildServiceProvider();
 
             return serviceProvider;
-        }
-
-        private static void InitLogger()
-        {
-            var hierarchy = (Hierarchy)LogManager.GetRepository(Assembly.GetExecutingAssembly());
-            var tracer = new TraceAppender();
-            var patternLayout = new PatternLayout();
-
-            patternLayout.ConversionPattern = "%d [%t] %-5p %m%n";
-            patternLayout.ActivateOptions();
-
-            tracer.Layout = patternLayout;
-            tracer.ActivateOptions();
-            hierarchy.Root.AddAppender(tracer);
-
-            var appender = new ConsoleAppender();
-            appender.Layout = patternLayout;
-            appender.ActivateOptions();
-            hierarchy.Root.AddAppender(appender);
-
-            hierarchy.Root.Level = Level.Info;
-            hierarchy.Configured = true;
         }
     }
 }

--- a/Examples/NonTransientMessageFailureHandling/Subscriber/Subscriber.csproj
+++ b/Examples/NonTransientMessageFailureHandling/Subscriber/Subscriber.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pat.Subscriber" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.RateLimiterPolicy" Version="1.1.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Pat.Subscriber" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.RateLimiterPolicy" Version="2.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/RateLimiting/Subscriber/FooHandler.cs
+++ b/Examples/RateLimiting/Subscriber/FooHandler.cs
@@ -1,22 +1,22 @@
 ﻿using System.Threading.Tasks;
 using Contract;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 
 namespace Subscriber
 {
     public class FooHandler : IHandleEvent<Foo>
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
 
-        public FooHandler(ILog log)
+        public FooHandler(ILogger log)
         {
             _log = log;
         }
 
         public Task HandleAsync(Foo @event)
         {
-            _log.Info($"Handling: {@event}");
+            _log.LogInformation($"Handling: {@event}");
             return Task.CompletedTask;
         }
     }

--- a/Examples/RateLimiting/Subscriber/Program.cs
+++ b/Examples/RateLimiting/Subscriber/Program.cs
@@ -2,12 +2,8 @@
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using log4net;
-using log4net.Appender;
-using log4net.Core;
-using log4net.Layout;
-using log4net.Repository.Hierarchy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 using Pat.Subscriber.BatchProcessing;
 using Pat.Subscriber.MessageProcessing;
@@ -26,14 +22,14 @@ namespace Subscriber
             var tokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, args) =>
             {
-                var log = serviceProvider.GetService<ILog>();
-                log.Info("Subscriber Shutdown Requested");
+                var log = serviceProvider.GetService<ILogger>();
+                log.LogInformation("Subscriber Shutdown Requested");
                 args.Cancel = true;
                 tokenSource.Cancel();
             };
 
             var subscriber = serviceProvider.GetService<Pat.Subscriber.Subscriber>();
-            await subscriber.Initialise(new[] {Assembly.GetExecutingAssembly()});
+            await subscriber.Initialise(new[] { Assembly.GetExecutingAssembly() });
             await subscriber.ListenForMessages(tokenSource);
         }
 
@@ -44,13 +40,11 @@ namespace Subscriber
 
             var subscriberConfiguration = new SubscriberConfiguration
             {
-                ConnectionStrings = new[] {connection},
+                ConnectionStrings = new[] { connection },
                 TopicName = topicName,
                 SubscriberName = "PatExampleSubscriber",
                 UseDevelopmentTopic = false
             };
-
-            InitLogger();
 
             var patLiteOptions = new PatLiteOptionsBuilder(subscriberConfiguration)
                 .DefineMessagePipeline
@@ -64,7 +58,8 @@ namespace Subscriber
 
             var serviceProvider = new ServiceCollection()
                 .AddPatLite(patLiteOptions)
-                .AddTransient(s => LogManager.GetLogger(s.GetType()))
+                .AddDefaultPatLogger()
+                .AddLogging(b => b.AddConsole())
                 .AddTransient<IStatisticsReporter, StatisticsReporter>()
                 .AddSingleton(new StatisticsReporterConfiguration())
                 .AddHandlersFromAssemblyContainingType<FooHandler>()
@@ -76,28 +71,6 @@ namespace Subscriber
                 .BuildServiceProvider();
 
             return serviceProvider;
-        }
-
-        private static void InitLogger()
-        {
-            var hierarchy = (Hierarchy)LogManager.GetRepository(Assembly.GetExecutingAssembly());
-            var tracer = new TraceAppender();
-            var patternLayout = new PatternLayout();
-
-            patternLayout.ConversionPattern = "%d [%t] %-5p %m%n";
-            patternLayout.ActivateOptions();
-
-            tracer.Layout = patternLayout;
-            tracer.ActivateOptions();
-            hierarchy.Root.AddAppender(tracer);
-
-            var appender = new ConsoleAppender();
-            appender.Layout = patternLayout;
-            appender.ActivateOptions();
-            hierarchy.Root.AddAppender(appender);
-
-            hierarchy.Root.Level = Level.All;
-            hierarchy.Configured = true;
         }
     }
 }

--- a/Examples/RateLimiting/Subscriber/Subscriber.csproj
+++ b/Examples/RateLimiting/Subscriber/Subscriber.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pat.Subscriber" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.RateLimiterPolicy" Version="1.1.20" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Pat.Subscriber" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.RateLimiterPolicy" Version="2.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Examples/StatsDTelemetry/Subscriber/FooHandler.cs
+++ b/Examples/StatsDTelemetry/Subscriber/FooHandler.cs
@@ -1,22 +1,22 @@
 ﻿using System.Threading.Tasks;
 using Contract;
-using log4net;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 
 namespace Subscriber
 {
     public class FooHandler : IHandleEvent<Foo>
     {
-        private readonly ILog _log;
+        private readonly ILogger _log;
 
-        public FooHandler(ILog log)
+        public FooHandler(ILogger log)
         {
             _log = log;
         }
 
         public Task HandleAsync(Foo @event)
         {
-            _log.Info($"Handling: {@event}");
+            _log.LogInformation($"Handling: {@event}");
             return Task.CompletedTask;
         }
     }

--- a/Examples/StatsDTelemetry/Subscriber/Program.cs
+++ b/Examples/StatsDTelemetry/Subscriber/Program.cs
@@ -2,12 +2,8 @@
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using log4net;
-using log4net.Appender;
-using log4net.Core;
-using log4net.Layout;
-using log4net.Repository.Hierarchy;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Pat.Subscriber;
 using Pat.Subscriber.NetCoreDependencyResolution;
 using Pat.Subscriber.Telemetry.StatsD;
@@ -23,8 +19,8 @@ namespace Subscriber
             var tokenSource = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, args) =>
             {
-                var log = serviceProvider.GetService<ILog>();
-                log.Info("Subscriber Shutdown Requested");
+                var log = serviceProvider.GetService<ILogger>();
+                log.LogInformation("Subscriber Shutdown Requested");
                 args.Cancel = true;
                 tokenSource.Cancel();
             };
@@ -47,11 +43,10 @@ namespace Subscriber
                 UseDevelopmentTopic = false
             };
 
-            InitLogger();
-
             var serviceProvider = new ServiceCollection()
                 .AddPatLite(subscriberConfiguration)
-                .AddTransient(s => LogManager.GetLogger(s.GetType()))
+                .AddDefaultPatLogger()
+                .AddLogging(b => b.AddConsole())
                 .AddTransient<IStatisticsReporter, StatisticsReporter>()
                 .AddSingleton(new StatisticsReporterConfiguration
                 {
@@ -64,28 +59,6 @@ namespace Subscriber
                 .BuildServiceProvider();
 
             return serviceProvider;
-        }
-
-        private static void InitLogger()
-        {
-            var hierarchy = (Hierarchy)LogManager.GetRepository(Assembly.GetExecutingAssembly());
-            var tracer = new TraceAppender();
-            var patternLayout = new PatternLayout();
-
-            patternLayout.ConversionPattern = "%d [%t] %-5p %m%n";
-            patternLayout.ActivateOptions();
-
-            tracer.Layout = patternLayout;
-            tracer.ActivateOptions();
-            hierarchy.Root.AddAppender(tracer);
-
-            var appender = new ConsoleAppender();
-            appender.Layout = patternLayout;
-            appender.ActivateOptions();
-            hierarchy.Root.AddAppender(appender);
-
-            hierarchy.Root.Level = Level.All;
-            hierarchy.Configured = true;
         }
     }
 }

--- a/Examples/StatsDTelemetry/Subscriber/Subscriber.csproj
+++ b/Examples/StatsDTelemetry/Subscriber/Subscriber.csproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pat.Subscriber" Version="1.1.20" />
-    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="1.1.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Pat.Subscriber" Version="2.0.21" />
+    <PackageReference Include="Pat.Subscriber.NetCoreDependencyResolution" Version="2.0.21" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
WRONG PACKAGE VERSIONS so this PR does not yet build - preview only - will force-push correct versions when Subscriber PR is approved and correct packages published.

Reflects dropped Subscriber support for .NET Framework 4.5.1